### PR TITLE
Add command line option configuration

### DIFF
--- a/bsec_bme680.c
+++ b/bsec_bme680.c
@@ -38,9 +38,6 @@ const char *argp_program_bug_address =
 static char doc[] =
   "bsec_bme680 - Read data from a Bosch BME680 environmental sensor via the BSEC library.";
 
-/* A description of the arguments we accept. */
-static char args_doc[] = "ARG1 ARG2";
-
 /* The options we understand. */
 static struct argp_option options[] = {
   {"address", 'a', "NUM",   0,  "I2C address of device (default: 0x76)"             },
@@ -89,7 +86,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
 }
 
 /* Argument parser. */
-static struct argp argp = { options, parse_opt, args_doc, doc };
+static struct argp argp = { options, parse_opt, 0, doc };
 
 #define DESTZONE "TZ=Europe/London"
 #define sample_rate_mode (BSEC_SAMPLE_RATE_LP)

--- a/bsec_bme680.c
+++ b/bsec_bme680.c
@@ -214,13 +214,13 @@ void output_ready(int64_t timestamp, float iaq, uint8_t iaq_accuracy,
   time_t t = time(NULL);
   struct tm tm = *localtime(&t);
 
-  printf("{ \"iaq\": \"%.2f\", \"iaq_accuracy\": \"%d\"", iaq, iaq_accuracy);
-  printf(", \"s_iaq\": \"%.2f\", \"s_iaq_accuracy\": \"%d\"", static_iaq, static_iaq_accuracy);
-  printf(", \"temperature\": \"%.2f\", \"humidity\": \"%.2f\", \"pressure\": \"%.2f\"", temperature, humidity,pressure / 100);
-  printf(", \"co2_equivalents\": \"%.2f\"", co2_equivalent);
-  printf(", \"breath_voc_equivalents\": \"%.2f\"", breath_voc_equivalent);
-  printf(", \"gas_resistance\": \"%.0f\", \"gas_percentage\": \"%.0f\"", gas, gas_percentage);
-  printf(", \"status\": \"%d\" }\n", bsec_status);
+  printf("{ \"iaq\": %.2f, \"iaq_accuracy\": %d", iaq, iaq_accuracy);
+  printf(", \"s_iaq\": %.2f, \"s_iaq_accuracy\": %d", static_iaq, static_iaq_accuracy);
+  printf(", \"temperature\": %.2f, \"humidity\": %.2f, \"pressure\": %.2f", temperature, humidity,pressure / 100);
+  printf(", \"co2_equivalents\": %.2f", co2_equivalent);
+  printf(", \"breath_voc_equivalents\": %.2f", breath_voc_equivalent);
+  printf(", \"gas_resistance\": %.0f, \"gas_percentage\": %.0f", gas, gas_percentage);
+  printf(", \"status\": %d }\n", bsec_status);
   fflush(stdout);
 }
 


### PR DESCRIPTION
Command line parameters can now be used to configure the I2C address, filenames of the config and state files, and the temperature offset to apply.

```
Usage: bsec_bme680 [OPTION...]
bsec_bme680 - Read data from a Bosch BME680 environmental sensor via the BSEC
library.

  -a, --address=NUM          I2C address of device (default: 0x76)
  -c, --config=FILE          Path to config file (default: 'bsec_iaq.config')
  -o, --offset=NUM           Temperature offset to apply (default: 0.0°C)
  -s, --state=FILE           Path to state file (default: 'bsec_iaq.state')
  -?, --help                 Give this help list
      --usage                Give a short usage message
  -V, --version              Print program version

Mandatory or optional arguments to long options are also mandatory or optional
for any corresponding short options.

Report bugs to https://github.com/imgrant/bsec_bme680_linux/issues.
```